### PR TITLE
fix: github actions release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release CI
 on:
   push:
     branches:
-    - master
-    - alpha
+    - nau/*.master
+
 jobs:
   release:
     name: Release
@@ -33,8 +33,15 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Build
       run: npm run build
-    - name: Release
+    - name: Release to npmjs
+      uses: pascalgn/npm-publish-action@1.3.9
+      with:
+        tag_name: "v%s"
+        tag_message: "v%s"
+        commit_pattern: "^chore(release): (\\S+)"
+        workspace: "."
+        publish_command: "npm"
+        publish_args: "--non-interactive"
       env:
         GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-      run: npx semantic-release
+        NPM_AUTH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@edx/frontend-component-footer",
-  "version": "1.0.0-semantically-released",
-  "description": "Footer component for use when building Open edX frontend applications",
+  "name": "@nauedu/frontend-component-footer",
+  "version": "18.0.0",
+  "description": "NAU footer component for Open edX",
   "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
@@ -25,14 +25,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/frontend-component-footer.git"
+    "url": "git+https://github.com/fccn/frontend-component-footer-nau.git"
   },
   "author": "edX",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/openedx/frontend-component-footer/issues"
+    "url": "https://github.com/fccn/frontend-component-footer-nau/issues"
   },
-  "homepage": "https://github.com/openedx/frontend-component-footer#readme",
+  "homepage": "https://github.com/fccn/frontend-component-footer-nau#readme",
   "devDependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "^1.1.1",


### PR DESCRIPTION
- change semantic-release to release based on package.json version.
- publishing the package occurs when the version number changes.
- action fires on commit with message "chore(release): vx", where x is the version.

Publish flow is equal to https://github.com/fccn/frontend-component-header-nau/pull/5