### PR TITLE
feat: add multiple line to additional logos

### DIFF
--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -25,7 +25,7 @@ $logo-color: #4e4e4e !default;
   flex-basis: 260px;
   min-width: 200px;
   font-size: 0.9rem;
-  
+
   span {
     font-weight: 600;
   }
@@ -46,5 +46,39 @@ $logo-color: #4e4e4e !default;
 
   &__badge {
     margin-right: 1.5rem;
+  }
+}
+
+.footer-additional-logos {
+  padding: 25px 65px;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
+  }
+
+  &__line {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    border-block-end: 1px solid #dedede;
+    padding: 1rem 0 1.6rem 0;
+    flex-basis: 0;
+
+    @media screen and (max-width: 768px) {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    img {
+      max-height: 4rem;
+      padding: 0 .5rem;
+      max-width: 100%;
+    }
+
+    &:last-child {
+      border: none;
+    }
   }
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -29,15 +29,15 @@ const AdditionalLogosSection = () => {
 
   return (
     <section className="footer-additional-logos">
-      <div className="d-md-flex justify-content-between px-4">
-        {logos.map((logo) => (
-          <div className="py-3">
+      {logos.map(line => (
+        <div className="footer-additional-logos__line">
+          {Array.isArray(line) && line.map(logo => (
             <a href={logo.url} target="_blank" rel="noopener noreferrer">
-              <img src={logo.src} alt={logo.alt} style={{ maxHeight: '45px', maxWidth: '280px' }} />
+              <img src={logo.src} alt={logo.alt} />
             </a>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      ))}
     </section>
   );
 };


### PR DESCRIPTION
- Add a way to create multiple lines on the footer, so that we can mimic the same behaviour that exists on the marketing site

The new setting has be created with the idea of 1 array per line, similar to this example:
```python
MFE_CONFIG["FOOTER_ADDITIONAL_LOGOS"] = '[[{"src": "https://nau-prod-richie-nau-media.rgw.nau.fccn.pt/media/filer_public_thumbnails/filer_public/2a/f5/2af51561-e2cd-4b12-8cbe-c62aca6e1727/barra.png__9851x1422_subsampling-2.png","alt": "PRR Plano de Recuperação e Resiliência, República Portuguesa, Financiado pela União Europeia NextGenerationEU","url": "https://www.fccn.pt/inovacao/projeto-nau-financiamento-sama/"},{"src": "https://nau-prod-richie-nau-media.rgw.nau.fccn.pt/media/filer_public_thumbnails/filer_public/64/a7/64a7c11d-c3f8-4487-95c0-46b3f8bb5236/4logos-feder_fse_nau_v2.png__600x720_subsampling-2.png","alt": "Compete2020, Portugal2020, União Europeia Fundo Europeu de Desenvolvimento Regional","url": "https://www.incode2030.gov.pt/"}], [{"src": "https://nau-prod-richie-nau-media.rgw.nau.fccn.pt/media/filer_public_thumbnails/filer_public/23/93/2393278b-fb7d-4f34-bfef-9bad17a2f71c/pt_preto_horizontal.svg__4563x1167.svg", "alt": "República Portuguesa, Ministério da Educação, Ciência e Inovação.", "url": "https://www.portugal.gov.pt/"}, {"src": "https://nau-prod-richie-nau-media.rgw.nau.fccn.pt/media/filer_public_thumbnails/filer_public/2d/7d/2d7d35ff-5b9b-4d15-83e6-8911a8393dd6/2024_logo-fccn-fct-b-preto.svg__852x190.svg", "alt": "FCCN - Serviços digitais FCT; FCT - Fundação para a Ciência e a Tecnologia", "url": "https://www.fccn.pt/"}]]'
```

https://github.com/fccn/nau-technical/issues/272