### PR TITLE
fix: validate dateJoined is defined before display the modal TOS

### DIFF
--- a/src/components/modal-tos/ModalToS.jsx
+++ b/src/components/modal-tos/ModalToS.jsx
@@ -80,8 +80,8 @@ const ModalToS = () => {
     }
   };
 
-  if (tosPreference || !dateIso8601 || !username
-    || new Date(dateIso8601) < new Date(dateJoined)) {
+  if (tosPreference || !dateIso8601 || !username || !dateJoined
+    || new Date(dateIso8601) <= new Date(dateJoined)) {
     return null;
   }
 


### PR DESCRIPTION
This PR adds a extra validation in case `dateJoined` was `undefined`   at the moment to compare the date with the TOS one. 



https://github.com/user-attachments/assets/9ef80c6f-cd39-483c-9263-66c5ff88a93c



