### PR TITLE
fix: modal tos text

### DIFF
--- a/src/components/modal-tos/ModalToS.jsx
+++ b/src/components/modal-tos/ModalToS.jsx
@@ -29,7 +29,6 @@ const ModalToS = () => {
   const {
     MODAL_UPDATE_TERMS_OF_SERVICE,
     PRIVACY_POLICY_URL,
-    SITE_NAME,
     TERMS_OF_SERVICE_URL,
     TOS_AND_HONOR_CODE,
   } = getConfig();
@@ -92,6 +91,7 @@ const ModalToS = () => {
       isOpen={isOpen}
       onClose={close}
       hasCloseButton={false}
+      size="lg"
     >
       {title[lang] && (
       <ModalDialog.Header>
@@ -127,10 +127,9 @@ const ModalToS = () => {
                   <FormattedMessage
                     id="modalToS.termsOfService.checkbox.label"
                     description="The label for the terms of service checkbox inside the TOS modal."
-                    defaultMessage="I agree to the {platformName}&nbsp;<a>Terms of Service</a>"
+                    defaultMessage="I have read, understood and accept the&nbsp;<a>Terms and Conditions</a>"
                     values={{
                       a: chunks => createTOSLink(chunks, TERMS_OF_SERVICE_URL),
-                      platformName: SITE_NAME,
                     }}
                   />
                 </Form.Checkbox>
@@ -141,10 +140,9 @@ const ModalToS = () => {
                   <FormattedMessage
                     id="modalToS.honorCode.checkbox.label"
                     description="The label for the honor code checkbox inside the TOS modal."
-                    defaultMessage="I agree to the {platformName}&nbsp;<a>Honor Code</a>"
+                    defaultMessage="I have read and understood the&nbsp;<a>Honor Code</a>"
                     values={{
                       a: chunks => createTOSLink(chunks, TOS_AND_HONOR_CODE),
-                      platformName: SITE_NAME,
                     }}
                   />
                 </Form.Checkbox>

--- a/src/components/modal-tos/ModalToS.test.jsx
+++ b/src/components/modal-tos/ModalToS.test.jsx
@@ -117,7 +117,7 @@ describe('ModalTOS Component', () => {
     expect(button).toBeDisabled();
 
     const privacyCheckbox = screen.getByLabelText(/Privacy Policy/i);
-    const termsCheckbox = screen.getByLabelText(/Terms of Service/i, { selector: 'input' });
+    const termsCheckbox = screen.getByLabelText(/Terms and Conditions/i, { selector: 'input' });
 
     fireEvent.click(privacyCheckbox); // Click first checkbox
     expect(button).toBeDisabled(); // Button should still be disabled
@@ -134,7 +134,7 @@ describe('ModalTOS Component', () => {
     await waitFor(() => screen.getByText(/Attention/i));
 
     const privacyCheckbox = screen.getByLabelText(/Privacy Policy/i);
-    const termsCheckbox = screen.getByLabelText(/Terms of Service/i, { selector: 'input' });
+    const termsCheckbox = screen.getByLabelText(/Terms and Conditions/i, { selector: 'input' });
 
     // Check all checkboxes
     fireEvent.click(privacyCheckbox);

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -3,7 +3,7 @@
     "footer.languageForm.submit.label": "Aplicar",
     "footer.copyright.message": "Todos os direitos reservados.",
     "modalToS.dataAuthorization.checkbox.label": "Li e compreendi a&nbsp;<a>Política de Privacidade</a>",
-    "modalToS.termsOfService.checkbox.label": "Li e compreendi o {platformName}&nbsp;<a>Termos e Condições</a>",
-    "modalToS.honorCode.checkbox.label": "Li e compreendi o {platformName}&nbsp;<a>Honor Code</a>",
+    "modalToS.termsOfService.checkbox.label": "Li, compreendi e aceito os&nbsp;<a>Termos e Condições</a>",
+    "modalToS.honorCode.checkbox.label": "Li e compreendi o&nbsp;<a>Código de Honra</a>",
     "modalToS.acceptance.button": "Aceito os novos termos de serviço"
 }


### PR DESCRIPTION
Fix the modal terms of service text to be compliance with GDPR. Enlarge the modal size so the bigger text is shown with better style.

fccn/nau-technical#367