### PR TITLE
feat: modify footer lang selector behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ Optionally, use the following variables to configure the Terms of Service Modal 
 * ``PRIVACY_POLICY_URL`` - The URL for the privacy policy.
 * ``TERMS_OF_SERVICE_URL`` - The URL for the terms of service.
 * ``TOS_AND_HONOR_CODE`` - The URL for the honor code.
-
+* ``ENABLE_FOOTER_LANG_SELECTOR`` - A boolean to enable the lnaguage selector in the footer component.
+* ``SITE_SUPPORTED_LENGUAGES`` - A list with all the languages to display in the selector.
 
 Installation
 ============
@@ -94,12 +95,6 @@ This library has the following exports:
 * ``messages``: Internationalization messages suitable for use with `@edx/frontend-platform/i18n <https://edx.github.io/frontend-platform/module-Internationalization.html>`_
 * ``dist/footer.scss``: A SASS file which contains style information for the component.  It should be imported into the micro-frontend's own SCSS file.
 
-<Footer /> component props
-==========================
-
-* onLanguageSelected: Provides the footer with an event handler for when the user selects a
-  language from its dropdown.
-* supportedLanguages: An array of objects representing available languages.  See example below for object shape.
 
 Terms of Service Modal
 =======================
@@ -156,13 +151,7 @@ Component Usage Example::
 
   ...
 
-  <Footer
-    onLanguageSelected={(languageCode) => {/* set language */}}
-    supportedLanguages={[
-      { label: 'English', value: 'en'},
-      { label: 'Español', value: 'es' },
-    ]}
-  />
+  <Footer />
 
 * `An example of minimal component and messages usage. <https://github.com/openedx/frontend-template-application/blob/3355bb3a96232390e9056f35b06ffa8f105ed7ca/src/index.jsx#L23>`_
 * `An example of SCSS file usage. <https://github.com/openedx/frontend-template-application/blob/3cd5485bf387b8c479baf6b02bf59e3061dc3465/src/index.scss#L9>`_

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Optionally, use the following variables to configure the Terms of Service Modal 
 * ``TERMS_OF_SERVICE_URL`` - The URL for the terms of service.
 * ``TOS_AND_HONOR_CODE`` - The URL for the honor code.
 * ``ENABLE_FOOTER_LANG_SELECTOR`` - A boolean to enable the lnaguage selector in the footer component.
-* ``SITE_SUPPORTED_LENGUAGES`` - A list with all the languages to display in the selector.
+* ``SITE_SUPPORTED_LANGUAGES`` - A list with all the languages to display in the selector.
 
 Installation
 ============

--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -8,6 +8,15 @@ $footer-links-navigation-color: $footer-text;
   background-color: $footer-background-color;
   padding-top: 2rem;
   padding-bottom: 2rem;
+
+  .language-selector {
+    button {
+      color: $footer-text;
+      padding: 0;
+      border: unset;
+      background-color: unset;
+    }
+  }
 }
 
 .footer-copyright {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -138,7 +138,7 @@ class SiteFooter extends React.Component {
               </a>
               <FooterCopyrightSection intl={intl} />
               {config.ENABLE_FOOTER_LANG_SELECTOR && (
-                <div class="mb-2">
+                <div className="mb-2">
                   <LanguageSelector
                     options={parseEnvSettings(config.SITE_SUPPORTED_LANGUAGES)}
                     authenticatedUser={authenticatedUser}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -137,17 +137,19 @@ class SiteFooter extends React.Component {
                 />
               </a>
               <FooterCopyrightSection intl={intl} />
+              {config.ENABLE_FOOTER_LANG_SELECTOR && (
+                <div class="mb-2">
+                  <LanguageSelector
+                    options={parseEnvSettings(config.SITE_SUPPORTED_LANGUAGES)}
+                    authenticatedUser={authenticatedUser}
+                  />
+                </div>
+              )}
               <FooterSocial intl={intl} />
               <FooterPoweredBy intl={intl} />
             </div>
             <FooterLinks intl={intl} />
 
-            {config.ENABLE_FOOTER_LANG_SELECTOR && (
-              <LanguageSelector
-                options={config.SITE_SUPPORTED_LENGUAGES}
-                authenticatedUser={authenticatedUser}
-              />
-            )}
           </div>
         </section>
         <AdditionalLogosSection />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -113,13 +113,10 @@ class SiteFooter extends React.Component {
 
   render() {
     const {
-      supportedLanguages,
-      onLanguageSelected,
       logo,
       intl,
     } = this.props;
-    const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
-    const { config } = this.context;
+    const { config, authenticatedUser } = this.context;
 
     return (
       <footer
@@ -145,18 +142,18 @@ class SiteFooter extends React.Component {
             </div>
             <FooterLinks intl={intl} />
 
-            {showLanguageSelector && (
+            {config.ENABLE_FOOTER_LANG_SELECTOR && (
               <LanguageSelector
-                options={supportedLanguages}
-                onSubmit={onLanguageSelected}
+                options={config.SITE_SUPPORTED_LENGUAGES}
+                authenticatedUser={authenticatedUser}
               />
             )}
           </div>
         </section>
         <AdditionalLogosSection />
         {
-        config.MODAL_UPDATE_TERMS_OF_SERVICE && <ModalToS />
-       }
+          config.MODAL_UPDATE_TERMS_OF_SERVICE && <ModalToS />
+        }
       </footer>
     );
   }
@@ -167,17 +164,10 @@ SiteFooter.contextType = AppContext;
 SiteFooter.propTypes = {
   intl: intlShape.isRequired,
   logo: PropTypes.string,
-  onLanguageSelected: PropTypes.func,
-  supportedLanguages: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
-  })),
 };
 
 SiteFooter.defaultProps = {
   logo: undefined,
-  onLanguageSelected: undefined,
-  supportedLanguages: [],
 };
 
 export default injectIntl(SiteFooter);

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -44,7 +44,7 @@ const FooterWithLanguageSelector = () => {
       LMS_BASE_URL: process.env.LMS_BASE_URL,
       SITE_NAME: process.env.SITE_NAME,
       ENABLE_FOOTER_LANG_SELECTOR: true,
-      SITE_SUPPORTED_LENGUAGES: [
+      SITE_SUPPORTED_LANGUAGES: [
         { label: 'English', value: 'en' },
         { label: 'Português', value: 'pt-pt' },
       ],

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -2,10 +2,18 @@
 import React, { useMemo } from 'react';
 import renderer from 'react-test-renderer';
 import { render, fireEvent, screen } from '@testing-library/react';
+import { initializeMockApp } from '@edx/frontend-platform';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import Footer from './Footer';
+
+import { patchPreferences, postSetLang } from './data/api';
+
+jest.mock('./data/api', () => ({
+  patchPreferences: jest.fn(),
+  postSetLang: jest.fn(),
+}));
 
 const FooterWithContext = ({ locale = 'pt-pt' }) => {
   const contextValue = useMemo(() => ({
@@ -13,6 +21,7 @@ const FooterWithContext = ({ locale = 'pt-pt' }) => {
     config: {
       LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
       LMS_BASE_URL: process.env.LMS_BASE_URL,
+      SITE_NAME: process.env.SITE_NAME,
     },
   }), []);
 
@@ -27,12 +36,18 @@ const FooterWithContext = ({ locale = 'pt-pt' }) => {
   );
 };
 
-const FooterWithLanguageSelector = ({ languageSelected = () => {} }) => {
+const FooterWithLanguageSelector = () => {
   const contextValue = useMemo(() => ({
-    authenticatedUser: null,
+    authenticatedUser: { username: 'user123' },
     config: {
       LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
       LMS_BASE_URL: process.env.LMS_BASE_URL,
+      SITE_NAME: process.env.SITE_NAME,
+      ENABLE_FOOTER_LANG_SELECTOR: true,
+      SITE_SUPPORTED_LENGUAGES: [
+        { label: 'English', value: 'en' },
+        { label: 'Português', value: 'pt-pt' },
+      ],
     },
   }), []);
 
@@ -41,13 +56,7 @@ const FooterWithLanguageSelector = ({ languageSelected = () => {} }) => {
       <AppContext.Provider
         value={contextValue}
       >
-        <Footer
-          onLanguageSelected={languageSelected}
-          supportedLanguages={[
-            { label: 'English', value: 'en' },
-            { label: 'Português', value: 'pt-pt' },
-          ]}
-        />
+        <Footer />
       </AppContext.Provider>
     </IntlProvider>
   );
@@ -76,11 +85,11 @@ describe('<Footer />', () => {
   });
 
   describe('handles language switching', () => {
-    it('calls onLanguageSelected prop when a language is changed', () => {
-      const mockHandleLanguageSelected = jest.fn();
-      render(<FooterWithLanguageSelector languageSelected={mockHandleLanguageSelected} />);
+    it('calls patchPreferences and postSetLang when a language is changed', async () => {
+      initializeMockApp();
+      render(<FooterWithLanguageSelector />);
 
-      fireEvent.submit(screen.getByTestId('site-footer-submit-btn'), {
+      await fireEvent.submit(screen.getByTestId('site-footer-submit-btn'), {
         target: {
           elements: {
             'site-footer-language-select': {
@@ -89,8 +98,8 @@ describe('<Footer />', () => {
           },
         },
       });
-
-      expect(mockHandleLanguageSelected).toHaveBeenCalledWith('pt-pt');
+      expect(patchPreferences).toHaveBeenCalledWith('user123', { prefLang: 'pt-pt' });
+      expect(postSetLang).toHaveBeenCalledWith('pt-pt');
     });
   });
 });

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -1,10 +1,13 @@
 /* eslint-disable react/prop-types */
 import React, { useMemo } from 'react';
 import renderer from 'react-test-renderer';
-import { render, fireEvent, screen } from '@testing-library/react';
+import {
+  render, waitFor,
+} from '@testing-library/react';
 import { initializeMockApp } from '@edx/frontend-platform';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
+import '@testing-library/jest-dom';
 
 import Footer from './Footer';
 
@@ -89,17 +92,21 @@ describe('<Footer />', () => {
       initializeMockApp();
       render(<FooterWithLanguageSelector />);
 
-      await fireEvent.submit(screen.getByTestId('site-footer-submit-btn'), {
-        target: {
-          elements: {
-            'site-footer-language-select': {
-              value: 'pt-pt',
-            },
-          },
-        },
+      await waitFor(() => {
+        document.querySelector('.language-selector');
       });
-      expect(patchPreferences).toHaveBeenCalledWith('user123', { prefLang: 'pt-pt' });
-      expect(postSetLang).toHaveBeenCalledWith('pt-pt');
+      expect(document.querySelectorAll('.language-selector').length).toBe(1);
+
+      document.querySelector('.language-selector>button').click();
+
+      Array.from(document.querySelectorAll('.dropdown-menu.show a')).filter((e) => e.innerHTML === 'Português')[0].click();
+
+      await waitFor(() => {
+        expect(patchPreferences).toHaveBeenCalledWith('user123', { prefLang: 'pt-pt' });
+      });
+      await waitFor(() => {
+        expect(postSetLang).toHaveBeenCalledWith('pt-pt');
+      });
     });
   });
 });

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -25,58 +25,57 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, compact, ...props
+  intl, options, authenticatedUser, compact,
 }) => {
-
   const languageLabel = (languageCode) => {
-    const option = options.find( ({ value, label }) => value === languageCode )
-    return option ? option.label : null
-  }
+    const option = options.find(({ value }) => value === languageCode);
+    return option ? option.label : null;
+  };
 
   const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
+    /* eslint-disable no-console */
     console.debug(previousSiteLanguage, languageCode, authenticatedUser);
 
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
 
-    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
+    const languageLabelElement = event.target.parentElement.parentElement.querySelector('.languageLabel');
+    languageLabelElement.innerHTML = languageLabel(languageCode);
   };
 
-  const currentLangLabel = languageLabel(intl.locale)
-  const showLabel = !Boolean(compact || false);
+  const currentLangLabel = languageLabel(intl.locale);
+  const showLabel = !(compact || false);
 
   return (
-    <>
-      <Dropdown className="language-selector">
-        <Dropdown.Toggle variant="outline-primary">
-          <FontAwesomeIcon icon={faGlobe} />
-          {showLabel && (
-            currentLangLabel ? (
-              <span class="pl-1 languageLabel">
-                {currentLangLabel}
-              </span>
-            ) : (
-              <span class="pl-1">
-                <FormattedMessage
-                  id="footer.languageForm.select.label"
-                  defaultMessage="Choose Language"
-                  description="The label for the laguage select part of the language selection form."
-                />
-              </span>
-            )
-          )}
-        </Dropdown.Toggle>
-        <Dropdown.Menu>
+    <Dropdown className="language-selector">
+      <Dropdown.Toggle variant="outline-primary">
+        <FontAwesomeIcon icon={faGlobe} />
+        {showLabel && (
+          currentLangLabel ? (
+            <span className="pl-1 languageLabel">
+              {currentLangLabel}
+            </span>
+          ) : (
+            <span className="pl-1">
+              <FormattedMessage
+                id="footer.languageForm.select.label"
+                defaultMessage="Choose Language"
+                description="The label for the laguage select part of the language selection form."
+              />
+            </span>
+          )
+        )}
+      </Dropdown.Toggle>
+      <Dropdown.Menu>
         {options.map(({ value, label }) => (
           <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
             {label}
           </Dropdown.Item>
         ))}
-        </Dropdown.Menu>
-      </Dropdown>
-    </>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 
@@ -90,6 +89,10 @@ LanguageSelector.propTypes = {
     value: PropTypes.string,
     label: PropTypes.string,
   })).isRequired,
+};
+
+LanguageSelector.defaultProps = {
+  compact: false,
 };
 
 export default injectIntl(LanguageSelector);

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -1,14 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { publish } from '@edx/frontend-platform';
+import {
+  getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
+} from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { patchPreferences, postSetLang } from './data/api';
+
+const onLanguageSelected = async (username, selectedLanguageCode) => {
+  try {
+    if (username) {
+      await patchPreferences(username, { prefLang: selectedLanguageCode });
+      await postSetLang(selectedLanguageCode);
+    }
+    publish(LOCALE_CHANGED, getLocale());
+    handleRtl();
+  } catch (error) {
+    logError(error);
+  }
+};
 
 const LanguageSelector = ({
-  intl, options, onSubmit, ...props
+  intl, options, authenticatedUser, ...props
 }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
+    const previousSiteLanguage = getLocale();
     const languageCode = e.target.elements['site-footer-language-select'].value;
-    onSubmit(languageCode);
+    if (previousSiteLanguage !== languageCode) {
+      onLanguageSelected(authenticatedUser?.username, languageCode);
+    }
   };
 
   return (
@@ -47,8 +69,10 @@ const LanguageSelector = ({
 };
 
 LanguageSelector.propTypes = {
+  authenticatedUser: PropTypes.shape({
+    username: PropTypes.string,
+  }).isRequired,
   intl: intlShape.isRequired,
-  onSubmit: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string,
     label: PropTypes.string,

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGlobe } from '@fortawesome/free-solid-svg-icons';
 import { publish } from '@edx/frontend-platform';
 import {
   getLocale, injectIntl, intlShape, FormattedMessage, LOCALE_CHANGED, handleRtl,
 } from '@edx/frontend-platform/i18n';
+import { Dropdown } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { patchPreferences, postSetLang } from './data/api';
@@ -22,49 +25,58 @@ const onLanguageSelected = async (username, selectedLanguageCode) => {
 };
 
 const LanguageSelector = ({
-  intl, options, authenticatedUser, ...props
+  intl, options, authenticatedUser, compact, ...props
 }) => {
-  const handleSubmit = (e) => {
-    e.preventDefault();
+
+  const languageLabel = (languageCode) => {
+    const option = options.find( ({ value, label }) => value === languageCode )
+    return option ? option.label : null
+  }
+
+  const handleChange = (languageCode, event) => {
     const previousSiteLanguage = getLocale();
-    const languageCode = e.target.elements['site-footer-language-select'].value;
+    console.debug(previousSiteLanguage, languageCode, authenticatedUser);
+
     if (previousSiteLanguage !== languageCode) {
       onLanguageSelected(authenticatedUser?.username, languageCode);
     }
+
+    event.target.parentElement.parentElement.querySelector(".languageLabel").innerHTML = languageLabel(languageCode);
   };
 
+  const currentLangLabel = languageLabel(intl.locale)
+  const showLabel = !Boolean(compact || false);
+
   return (
-    <form
-      className="form-inline"
-      onSubmit={handleSubmit}
-      {...props}
-    >
-      <div className="form-group">
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label htmlFor="site-footer-language-select" className="d-inline-block m-0">
-          <FormattedMessage
-            id="footer.languageForm.select.label"
-            defaultMessage="Choose Language"
-            description="The label for the laguage select part of the language selection form."
-          />
-        </label>
-        <select
-          id="site-footer-language-select"
-          className="form-control-sm mx-2"
-          name="site-footer-language-select"
-          defaultValue={intl.locale}
-        >
-          {options.map(({ value, label }) => <option key={value} value={value}>{label}</option>)}
-        </select>
-        <button data-testid="site-footer-submit-btn" className="btn btn-outline-primary btn-sm" type="submit">
-          <FormattedMessage
-            id="footer.languageForm.submit.label"
-            defaultMessage="Apply"
-            description="The label for button to submit the language selection form."
-          />
-        </button>
-      </div>
-    </form>
+    <>
+      <Dropdown className="language-selector">
+        <Dropdown.Toggle variant="outline-primary">
+          <FontAwesomeIcon icon={faGlobe} />
+          {showLabel && (
+            currentLangLabel ? (
+              <span class="pl-1 languageLabel">
+                {currentLangLabel}
+              </span>
+            ) : (
+              <span class="pl-1">
+                <FormattedMessage
+                  id="footer.languageForm.select.label"
+                  defaultMessage="Choose Language"
+                  description="The label for the laguage select part of the language selection form."
+                />
+              </span>
+            )
+          )}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+        {options.map(({ value, label }) => (
+          <Dropdown.Item key={value} eventKey={value} onSelect={handleChange}>
+            {label}
+          </Dropdown.Item>
+        ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
   );
 };
 
@@ -73,6 +85,7 @@ LanguageSelector.propTypes = {
     username: PropTypes.string,
   }).isRequired,
   intl: intlShape.isRequired,
+  compact: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string,
     label: PropTypes.string,

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -36,46 +36,47 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
            - FCT|FCCN 
           All rights reserved
         </div>
-      </div>
-      <form
-        className="form-inline"
-        onSubmit={[Function]}
-      >
         <div
-          className="form-group"
+          className="mb-2"
         >
-          <label
-            className="d-inline-block m-0"
-            htmlFor="site-footer-language-select"
+          <div
+            className="pgn__dropdown pgn__dropdown-light language-selector dropdown"
+            data-testid="dropdown"
           >
-            Choose Language
-          </label>
-          <select
-            className="form-control-sm mx-2"
-            defaultValue="en"
-            id="site-footer-language-select"
-            name="site-footer-language-select"
-          >
-            <option
-              value="en"
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="dropdown-toggle btn btn-outline-primary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
             >
-              English
-            </option>
-            <option
-              value="pt-pt"
-            >
-              Português
-            </option>
-          </select>
-          <button
-            className="btn btn-outline-primary btn-sm"
-            data-testid="site-footer-submit-btn"
-            type="submit"
-          >
-            Apply
-          </button>
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-globe "
+                data-icon="globe"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={{}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M352 256c0 22.2-1.2 43.6-3.3 64H163.3c-2.2-20.4-3.3-41.8-3.3-64s1.2-43.6 3.3-64H348.7c2.2 20.4 3.3 41.8 3.3 64zm28.8-64H503.9c5.3 20.5 8.1 41.9 8.1 64s-2.8 43.5-8.1 64H380.8c2.1-20.6 3.2-42 3.2-64s-1.1-43.4-3.2-64zm112.6-32H376.7c-10-63.9-29.8-117.4-55.3-151.6c78.3 20.7 142 77.5 171.9 151.6zm-149.1 0H167.7c6.1-36.4 15.5-68.6 27-94.7c10.5-23.6 22.2-40.7 33.5-51.5C239.4 3.2 248.7 0 256 0s16.6 3.2 27.8 13.8c11.3 10.8 23 27.9 33.5 51.5c11.6 26 20.9 58.2 27 94.7zm-209 0H18.6C48.6 85.9 112.2 29.1 190.6 8.4C165.1 42.6 145.3 96.1 135.3 160zM8.1 192H131.2c-2.1 20.6-3.2 42-3.2 64s1.1 43.4 3.2 64H8.1C2.8 299.5 0 278.1 0 256s2.8-43.5 8.1-64zM194.7 446.6c-11.6-26-20.9-58.2-27-94.6H344.3c-6.1 36.4-15.5 68.6-27 94.6c-10.5 23.6-22.2 40.7-33.5 51.5C272.6 508.8 263.3 512 256 512s-16.6-3.2-27.8-13.8c-11.3-10.8-23-27.9-33.5-51.5zM135.3 352c10 63.9 29.8 117.4 55.3 151.6C112.2 482.9 48.6 426.1 18.6 352H135.3zm358.1 0c-30 74.1-93.6 130.9-171.9 151.6c25.5-34.2 45.2-87.7 55.3-151.6H493.4z"
+                  fill="currentColor"
+                  style={{}}
+                />
+              </svg>
+              <span
+                className="pl-1 languageLabel"
+              >
+                English
+              </span>
+            </button>
+          </div>
         </div>
-      </form>
+      </div>
     </div>
   </section>
 </footer>

--- a/src/components/data/api.js
+++ b/src/components/data/api.js
@@ -1,0 +1,32 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { convertKeyNames, snakeCaseObject } from '@edx/frontend-platform/utils';
+
+export async function patchPreferences(username, params) {
+  let processedParams = snakeCaseObject(params);
+  processedParams = convertKeyNames(processedParams, {
+    pref_lang: 'pref-lang',
+  });
+
+  await getAuthenticatedHttpClient()
+    .patch(`${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`, processedParams, {
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+    });
+
+  return params;
+}
+
+export async function postSetLang(code) {
+  const formData = new FormData();
+  const requestConfig = {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  };
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
+  formData.append('language', code);
+
+  await getAuthenticatedHttpClient()
+    .post(url, formData, requestConfig);
+}


### PR DESCRIPTION
This PR modifies the language selector behavior updating the user preference and changing the language on the fly.

**How to test**
- Use the current PR in the test instance
- Be sure the app has the translations in the supported languages.
- Add ``ENABLE_FOOTER_LANG_SELECTOR``  and ``SITE_SUPPORTED_LENGUAGES``  into the instance settings
- Test the selector


https://github.com/user-attachments/assets/e8b59b96-0a92-4d71-bdaf-aadc45d72765

