### PR TITLE
fix(modaltos): fix Modal Terms of Service translation presentation and title

### DIFF
--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -98,3 +98,14 @@ $footer-links-navigation-color: $footer-text;
     }
   }
 }
+
+.modal-terms-of-service {
+  .pgn__form-label{
+    .standalone-link {
+      &:before {
+        // Add a white space before MODAL TOS checkbox links
+        content: "\00a0";
+      }
+    }
+  }
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -154,7 +154,7 @@ class SiteFooter extends React.Component {
         </section>
         <AdditionalLogosSection />
         {
-          config.MODAL_UPDATE_TERMS_OF_SERVICE && <ModalToS />
+          config.MODAL_UPDATE_TERMS_OF_SERVICE && <ModalToS intl={intl} />
         }
       </footer>
     );

--- a/src/components/modal-tos/ModalToS.jsx
+++ b/src/components/modal-tos/ModalToS.jsx
@@ -92,6 +92,7 @@ const ModalToS = () => {
       onClose={close}
       hasCloseButton={false}
       size="lg"
+      className="modal-terms-of-service"
     >
       {title[lang] && (
       <ModalDialog.Header>
@@ -114,7 +115,7 @@ const ModalToS = () => {
                   <FormattedMessage
                     id="modalToS.dataAuthorization.checkbox.label"
                     description="The label for the data authorization checkbox inside the TOS modal."
-                    defaultMessage="I have read and understood the&nbsp;<a>Privacy Policy</a>"
+                    defaultMessage="I have read and understood the <a>Privacy Policy</a>"
                     values={{
                       a: chunks => createTOSLink(chunks, PRIVACY_POLICY_URL),
                     }}
@@ -127,7 +128,7 @@ const ModalToS = () => {
                   <FormattedMessage
                     id="modalToS.termsOfService.checkbox.label"
                     description="The label for the terms of service checkbox inside the TOS modal."
-                    defaultMessage="I have read, understood and accept the&nbsp;<a>Terms and Conditions</a>"
+                    defaultMessage="I have read, understood and accept the <a>Terms and Conditions</a>"
                     values={{
                       a: chunks => createTOSLink(chunks, TERMS_OF_SERVICE_URL),
                     }}
@@ -140,7 +141,7 @@ const ModalToS = () => {
                   <FormattedMessage
                     id="modalToS.honorCode.checkbox.label"
                     description="The label for the honor code checkbox inside the TOS modal."
-                    defaultMessage="I have read and understood the&nbsp;<a>Honor Code</a>"
+                    defaultMessage="I have read and understood the <a>Honor Code</a>"
                     values={{
                       a: chunks => createTOSLink(chunks, TOS_AND_HONOR_CODE),
                     }}

--- a/src/components/modal-tos/ModalToS.jsx
+++ b/src/components/modal-tos/ModalToS.jsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from 'react';
 
 import { convertKeyNames, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { FormattedMessage, getLocale, injectIntl } from '@edx/frontend-platform/i18n';
+import {
+  FormattedMessage, getLocale, injectIntl, intlShape,
+} from '@edx/frontend-platform/i18n';
 import {
   Button, Form, Hyperlink, ModalDialog, useToggle, useCheckboxSetValues,
   ActionRow,
@@ -21,7 +23,7 @@ const createTOSLink = (chunks, url) => (
   </Hyperlink>
 );
 
-const ModalToS = () => {
+const ModalToS = ({ intl }) => {
   const [tosPreference, setTosPreference] = useState(undefined);
   const [isOpen, open, close] = useToggle(false);
   const { width } = useWindowSize();
@@ -86,7 +88,7 @@ const ModalToS = () => {
 
   return (
     <ModalDialog
-      title="Modal Terms of Service"
+      title={intl.formatMessage({ id: 'modalToS.modalDialog.title', description: 'The Modal Terms of Service Title', defaultMessage: 'Modal accept Terms of Service' })}
       isBlocking
       isOpen={isOpen}
       onClose={close}
@@ -167,6 +169,10 @@ const ModalToS = () => {
       </ModalDialog.Body>
     </ModalDialog>
   );
+};
+
+ModalToS.propTypes = {
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(ModalToS);

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -2,8 +2,8 @@
     "footer.languageForm.select.label": "Escolha a língua",
     "footer.languageForm.submit.label": "Aplicar",
     "footer.copyright.message": "Todos os direitos reservados.",
-    "modalToS.dataAuthorization.checkbox.label": "Li e compreendi a&nbsp;<a>Política de Privacidade</a>",
-    "modalToS.termsOfService.checkbox.label": "Li, compreendi e aceito os&nbsp;<a>Termos e Condições</a>",
-    "modalToS.honorCode.checkbox.label": "Li e compreendi o&nbsp;<a>Código de Honra</a>",
+    "modalToS.dataAuthorization.checkbox.label": "Li e compreendi a <a>Política de Privacidade</a>",
+    "modalToS.termsOfService.checkbox.label": "Li, compreendi e aceito os <a>Termos e Condições</a>",
+    "modalToS.honorCode.checkbox.label": "Li e compreendi o <a>Código de Honra</a>",
     "modalToS.acceptance.button": "Aceito os novos termos de serviço"
-}
+  }

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -2,6 +2,7 @@
     "footer.languageForm.select.label": "Escolha a língua",
     "footer.languageForm.submit.label": "Aplicar",
     "footer.copyright.message": "Todos os direitos reservados.",
+    "modalToS.modalDialog.title": "Modal aceitar Termos de Serviço",
     "modalToS.dataAuthorization.checkbox.label": "Li e compreendi a <a>Política de Privacidade</a>",
     "modalToS.termsOfService.checkbox.label": "Li, compreendi e aceito os <a>Termos e Condições</a>",
     "modalToS.honorCode.checkbox.label": "Li e compreendi o <a>Código de Honra</a>",


### PR DESCRIPTION
fix(modaltos): fix translation presentation 

The Modal Terms of Service was presenting the `&nbsp;` when using
the pt_pt or pt locales.

fix(modaltos): Translate modal ToS title 

fccn/nau-technical#367